### PR TITLE
BXMSDOC-8055 Removes reference to KieLoginModule

### DIFF
--- a/doc-content/enterprise-only/admin-and-config/kie-server-accessing-runtime-data-proc.adoc
+++ b/doc-content/enterprise-only/admin-and-config/kie-server-accessing-runtime-data-proc.adoc
@@ -16,9 +16,3 @@ These pages use the credentials of the currently logged in user to load data fro
 * The user exists in the KIE container (deployment unit) running the {CENTRAL} application. This user must have `admin`, `analyst`, or `developer` roles assigned, in addition to the `kie-server` role, with full access to the runtime data. The `manager` and `process_admin` roles also allow access to runtime data pages in {CENTRAL}.
 * The user exists in the KIE container (deployment unit) running {KIE_SERVER} and has the `kie-server` role assigned.
 * Communication between {CENTRAL} and {KIE_SERVER} is established. That is, {KIE_SERVER} is registered in the {CONTROLLER}, which is part of {CENTRAL}.
-* The `deployment.{URL_COMPONENT_CENTRAL}.war` login module is present in the `standalone.xml` configuration of the server running {CENTRAL}:
-+
-[source,subs="attributes+"]
-----
- <login-module code="org.kie.security.jaas.KieLoginModule" flag="optional" module="deployment.{URL_COMPONENT_CENTRAL}.war"/>
-----


### PR DESCRIPTION
[Rendered text](http://file.ork.redhat.com/~bdooley/BXMSDOC-8055-RHPAM/index.html#kie-server-accessing-runtime-data-proc).
